### PR TITLE
Draw path tools

### DIFF
--- a/src/elements/widgets/designerView/tools/DrawPathTool.ts
+++ b/src/elements/widgets/designerView/tools/DrawPathTool.ts
@@ -6,6 +6,13 @@ import { ITool } from './ITool';
 import { DesignItem } from '../../../item/DesignItem';
 import { OverlayLayer } from '../extensions/OverlayLayer.js';
 import { ServiceContainer } from '../../../services/ServiceContainer.js';
+import { IPoint } from '../../../..';
+
+let lastPoint: IPoint = { x: 0, y: 0 };
+let samePoint = false;
+let p2pMode = false;
+let pointerMoved = false;
+let eventStarted = false;
 
 export class DrawPathTool implements ITool {
 
@@ -13,7 +20,7 @@ export class DrawPathTool implements ITool {
 
   private _pathD: string;
   private _path: SVGPathElement;
-  
+
   constructor() {
   }
 
@@ -25,11 +32,13 @@ export class DrawPathTool implements ITool {
 
   pointerEventHandler(designerCanvas: IDesignerCanvas, event: PointerEvent, currentElement: Element) {
     const currentPoint = designerCanvas.getNormalizedEventCoordinates(event);
-
     const offset = 50;
+
 
     switch (event.type) {
       case EventNames.PointerDown:
+        eventStarted = true;
+        console.log("event started: " + eventStarted);
         (<Element>event.target).setPointerCapture(event.pointerId);
         this._path = document.createElementNS("http://www.w3.org/2000/svg", "path");
         this._pathD = "M" + currentPoint.x + " " + currentPoint.y;
@@ -37,40 +46,96 @@ export class DrawPathTool implements ITool {
         this._path.setAttribute("stroke", designerCanvas.serviceContainer.globalContext.strokeColor);
         this._path.setAttribute("fill", designerCanvas.serviceContainer.globalContext.fillBrush);
         designerCanvas.overlayLayer.addOverlay(this._path, OverlayLayer.Foregorund);
+
+        if (lastPoint.x === currentPoint.x && lastPoint.y == currentPoint.y) {
+          samePoint = true;
+          console.log("Same Point: " + samePoint);
+        }
+
+        lastPoint = currentPoint;
         break;
 
       case EventNames.PointerMove:
-        if (this._path) {
-          this._pathD += "L" + currentPoint.x + " " + currentPoint.y;
-          this._path.setAttribute("d", this._pathD);
+        if (eventStarted) {
+          pointerMoved = true;
+          console.log("pointer moved: " + pointerMoved);
+        }
+        if (!p2pMode) {
+          if (this._path) {
+            this._pathD += "L" + currentPoint.x + " " + currentPoint.y;
+            this._path.setAttribute("d", this._pathD);
+          }
         }
         break;
 
       case EventNames.PointerUp:
         (<Element>event.target).releasePointerCapture(event.pointerId);
-        const rect = this._path.getBoundingClientRect();
+        if (eventStarted && !pointerMoved) {
+          p2pMode = true;
+          console.log("p2pMode" + p2pMode);
+        }
+        if (p2pMode) {
+          this._pathD += "L" + currentPoint.x + " " + currentPoint.y;
+          this._path.setAttribute("d", this._pathD);
+        }
+        else {
+          // const rect = this._path.getBoundingClientRect();
 
-        designerCanvas.overlayLayer.removeOverlay(this._path);
-        const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+          // designerCanvas.overlayLayer.removeOverlay(this._path);
+          // const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
 
-        const mvX = rect.x - designerCanvas.containerBoundingRect.x - offset;
-        const mvY = rect.y - designerCanvas.containerBoundingRect.y - offset;
-        const d = movePathData(this._path, mvX, mvY);
-        this._path.setAttribute("d", d);
-        svg.appendChild(this._path);
-        svg.style.left = (mvX) + 'px';
-        svg.style.top = (mvY) + 'px';
-        svg.style.position = 'absolute';
-        svg.style.width = (rect.width + 2 * offset) + 'px';
-        svg.style.height = (rect.height + 2 * offset) + 'px';
-        //designerView.rootDesignItem.element.appendChild(svg);
-        this._path = null;
-        this._pathD = null;
+          // const mvX = rect.x - designerCanvas.containerBoundingRect.x - offset;
+          // const mvY = rect.y - designerCanvas.containerBoundingRect.y - offset;
+          // const d = movePathData(this._path, mvX, mvY);
+          // this._path.setAttribute("d", d);
+          // svg.appendChild(this._path);
+          // svg.style.left = (mvX) + 'px';
+          // svg.style.top = (mvY) + 'px';
+          // svg.style.position = 'absolute';
+          // svg.style.width = (rect.width + 2 * offset) + 'px';
+          // svg.style.height = (rect.height + 2 * offset) + 'px';
+          // //designerView.rootDesignItem.element.appendChild(svg);
+          // this._path = null;
+          // this._pathD = null;
 
-        const di = DesignItem.createDesignItemFromInstance(svg, designerCanvas.serviceContainer, designerCanvas.instanceServiceContainer);
-        designerCanvas.instanceServiceContainer.undoService.execute(new InsertAction(designerCanvas.rootDesignItem, designerCanvas.rootDesignItem.childCount, di));
+          // const di = DesignItem.createDesignItemFromInstance(svg, designerCanvas.serviceContainer, designerCanvas.instanceServiceContainer);
+          // designerCanvas.instanceServiceContainer.undoService.execute(new InsertAction(designerCanvas.rootDesignItem, designerCanvas.rootDesignItem.childCount, di));
 
-        designerCanvas.serviceContainer.globalContext.finishedWithTool(this);
+        }
+        if (samePoint && p2pMode) {
+          eventStarted = false;
+          p2pMode = false;
+          pointerMoved = false;
+          samePoint = false;
+          console.log("event started: " + eventStarted);
+          console.log("p2pMode: " + p2pMode);
+          console.log("pointer moved: " + pointerMoved);
+          console.log("same point: " + samePoint);
+
+          const rect = this._path.getBoundingClientRect();
+
+          designerCanvas.overlayLayer.removeOverlay(this._path);
+          const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+
+          const mvX = rect.x - designerCanvas.containerBoundingRect.x - offset;
+          const mvY = rect.y - designerCanvas.containerBoundingRect.y - offset;
+          const d = movePathData(this._path, mvX, mvY);
+          this._path.setAttribute("d", d);
+          svg.appendChild(this._path);
+          svg.style.left = (mvX) + 'px';
+          svg.style.top = (mvY) + 'px';
+          svg.style.position = 'absolute';
+          svg.style.width = (rect.width + 2 * offset) + 'px';
+          svg.style.height = (rect.height + 2 * offset) + 'px';
+          //designerView.rootDesignItem.element.appendChild(svg);
+          this._path = null;
+          this._pathD = null;
+
+          const di = DesignItem.createDesignItemFromInstance(svg, designerCanvas.serviceContainer, designerCanvas.instanceServiceContainer);
+          designerCanvas.instanceServiceContainer.undoService.execute(new InsertAction(designerCanvas.rootDesignItem, designerCanvas.rootDesignItem.childCount, di));
+
+          designerCanvas.serviceContainer.globalContext.finishedWithTool(this);
+        }
         //TODO: Better Path drawing (like in SVGEDIT & Adding via Undo Framework. And adding to correct container)
 
         break;

--- a/src/elements/widgets/designerView/tools/DrawPathTool.ts
+++ b/src/elements/widgets/designerView/tools/DrawPathTool.ts
@@ -8,7 +8,6 @@ import { OverlayLayer } from '../extensions/OverlayLayer.js';
 import { ServiceContainer } from '../../../services/ServiceContainer.js';
 import { IPoint } from '../../../..';
 
-let lastPoint: IPoint = { x: 0, y: 0 };
 
 
 export class DrawPathTool implements ITool {
@@ -22,7 +21,8 @@ export class DrawPathTool implements ITool {
   private _dragMode = false;
   private _pointerMoved = false;
   private _eventStarted = false;
-
+  private _lastPoint: IPoint = { x: 0, y: 0 };
+  
   constructor() {
   }
 
@@ -51,11 +51,11 @@ export class DrawPathTool implements ITool {
           designerCanvas.overlayLayer.addOverlay(this._path, OverlayLayer.Foregorund);
         }
 
-        if (lastPoint.x === currentPoint.x && lastPoint.y === currentPoint.y && !this._samePoint) {
+        if (this._lastPoint.x === currentPoint.x && this._lastPoint.y === currentPoint.y && !this._samePoint) {
           this._samePoint = true;
         }
 
-        lastPoint = currentPoint;
+        this._lastPoint = currentPoint;
         break;
 
 
@@ -82,6 +82,7 @@ export class DrawPathTool implements ITool {
           if (this._path) {
             if(event.shiftKey){
               console.log("Clicked with Shift Down");
+
               this._pathD += "L" + currentPoint.x + " " + currentPoint.y;
               this._path.setAttribute("d", this._pathD);
             }

--- a/src/elements/widgets/designerView/tools/DrawPathTool.ts
+++ b/src/elements/widgets/designerView/tools/DrawPathTool.ts
@@ -9,19 +9,19 @@ import { ServiceContainer } from '../../../services/ServiceContainer.js';
 import { IPoint } from '../../../..';
 
 let lastPoint: IPoint = { x: 0, y: 0 };
-let samePoint = false;
-let p2pMode = false;
-let dragMode = false;
-let pointerMoved = false;
-let eventStarted = false;
 
 
 export class DrawPathTool implements ITool {
-
+  
   readonly cursor = 'crosshair';
-
+  
   private _pathD: string;
   private _path: SVGPathElement;
+  private _samePoint = false;
+  private _p2pMode = false;
+  private _dragMode = false;
+  private _pointerMoved = false;
+  private _eventStarted = false;
 
   constructor() {
   }
@@ -39,9 +39,9 @@ export class DrawPathTool implements ITool {
 
     switch (event.type) {
       case EventNames.PointerDown:
-        eventStarted = true;
+        this._eventStarted = true;
 
-        if (!p2pMode) {
+        if (!this._p2pMode) {
           (<Element>event.target).setPointerCapture(event.pointerId);
           this._path = document.createElementNS("http://www.w3.org/2000/svg", "path");
           this._pathD = "M" + currentPoint.x + " " + currentPoint.y;
@@ -51,8 +51,8 @@ export class DrawPathTool implements ITool {
           designerCanvas.overlayLayer.addOverlay(this._path, OverlayLayer.Foregorund);
         }
 
-        if (lastPoint.x === currentPoint.x && lastPoint.y === currentPoint.y && !samePoint) {
-          samePoint = true;
+        if (lastPoint.x === currentPoint.x && lastPoint.y === currentPoint.y && !this._samePoint) {
+          this._samePoint = true;
         }
 
         lastPoint = currentPoint;
@@ -60,37 +60,44 @@ export class DrawPathTool implements ITool {
 
 
       case EventNames.PointerMove:
-        if (eventStarted) {
-          pointerMoved = true;
+        if (this._eventStarted) {
+          this._pointerMoved = true;
         }
-        if (!p2pMode) {
-          dragMode = true;
+        if (!this._p2pMode) {
+          this._dragMode = true;
           if (this._path) {
             this._pathD += "L" + currentPoint.x + " " + currentPoint.y;
             this._path.setAttribute("d", this._pathD);
           }
         }
         break;
-
+        
 
       case EventNames.PointerUp:
         (<Element>event.target).releasePointerCapture(event.pointerId);
-        if (eventStarted && !pointerMoved) {
-          p2pMode = true;
+        if (this._eventStarted && !this._pointerMoved) {
+          this._p2pMode = true;
         }
-        if (p2pMode && !samePoint) {
+        if (this._p2pMode && !this._samePoint) {
           if (this._path) {
-            this._pathD += "L" + currentPoint.x + " " + currentPoint.y;
-            this._path.setAttribute("d", this._pathD);
+            if(event.shiftKey){
+              console.log("Clicked with Shift Down");
+              this._pathD += "L" + currentPoint.x + " " + currentPoint.y;
+              this._path.setAttribute("d", this._pathD);
+            }
+            else {
+              this._pathD += "L" + currentPoint.x + " " + currentPoint.y;
+              this._path.setAttribute("d", this._pathD);
+            }
           }
         }
 
-        if (samePoint && p2pMode || dragMode && !p2pMode) {
-          eventStarted = false;
-          p2pMode = false;
-          pointerMoved = false;
-          samePoint = false;
-          dragMode = false;
+        if (this._samePoint && this._p2pMode || this._dragMode && !this._p2pMode) {
+          this._eventStarted = false;
+          this._p2pMode = false;
+          this._pointerMoved = false;
+          this._samePoint = false;
+          this._dragMode = false;
 
           const rect = this._path.getBoundingClientRect();
           designerCanvas.overlayLayer.removeOverlay(this._path);


### PR DESCRIPTION
Added a mode to the DrawPathTool.

Wherever you click once it will go in "Point to Point Mode" and only add points when you press the mouse button. When you press the mouse button twice on the same point it will exit the DrawPathTool.

When you move the pointer while the mouse button is still pressed, it will create a path following the pointer. Releasing the mouse button will exit the DrawPathTool.