### PR TITLE
Draw tools

### DIFF
--- a/src/elements/helper/PathDataPolyfill.ts
+++ b/src/elements/helper/PathDataPolyfill.ts
@@ -1106,7 +1106,7 @@ declare type PathDataC = { type: 'C' | 'c', values: [x1: number, y1: number, x2:
 declare type PathDataS = { type: 'S' | 's', values: [x2: number, y2: number, x: number, y: number] }
 declare type PathDataQ = { type: 'Q' | 'q', values: [x1: number, y1: number, x: number, y: number] }
 declare type PathDataA = { type: 'A' | 'a', values: [rx: number, ry: number, ang: number, flag1: 0 | 1, flag2: 0 | 1, x: number, y: number] }
-declare type PathData = { type: string } & (PathDataM | PathDataL | PathDataH | PathDataV | PathDataZ | PathDataC | PathDataS | PathDataQ | PathDataT | PathDataA)[];
+export declare type PathData = { type: string } & (PathDataM | PathDataL | PathDataH | PathDataV | PathDataZ | PathDataC | PathDataS | PathDataQ | PathDataT | PathDataA)[];
 
 export function straightenLine(p1: IPoint, p2: IPoint): IPoint {
   let newP = p2;

--- a/src/elements/widgets/designerView/extensions/PathExtension.ts
+++ b/src/elements/widgets/designerView/extensions/PathExtension.ts
@@ -5,19 +5,16 @@ import "../../../helper/PathDataPolyfill";
 import { IPoint } from "../../../../interfaces/IPoint";
 import { IExtensionManager } from "./IExtensionManger";
 import { EventNames } from "../../../../enums/EventNames";
+import { PathData } from "../../../helper/PathDataPolyfill";
 
 export class PathExtension extends AbstractExtension {
   //private _itemRect: DOMRect;
   //private _svgRect: DOMRect;
   private _lastPos: IPoint
   private _parentRect: DOMRect;
-  private _circle: SVGCircleElement;
-  private _circle2: SVGCircleElement;
   private _startPos: IPoint;
-
-  private _rect: DOMRect;
-  private _computed: CSSStyleDeclaration;
-  private _to: string[];
+  private _circlePos: IPoint;
+  private _pathdata: PathData[];
 
   constructor(extensionManager: IExtensionManager, designerView: IDesignerCanvas, extendedItem: IDesignItem) {
     super(extensionManager, designerView, extendedItem);
@@ -27,15 +24,15 @@ export class PathExtension extends AbstractExtension {
     //this._itemRect = this.extendedItem.element.getBoundingClientRect();
     //this._svgRect = (<SVGGeometryElement>this.extendedItem.element).ownerSVGElement.getBoundingClientRect();
     this._parentRect = (<SVGGeometryElement>this.extendedItem.element).parentElement.getBoundingClientRect();
-    const pathdata: any = (<SVGGraphicsElement>this.extendedItem.node).getPathData({ normalize: true });
-    for (let p of pathdata) {
+    this._pathdata = (<SVGGraphicsElement>this.extendedItem.node).getPathData({ normalize: true });
+    for (let p of this._pathdata) {
       switch (p.type) {
         case 'M':
-          this._drawPathCircle(p.values[0], p.values[1]);
+          this._drawPathCircle(p.values[0], p.values[1], p, 0);
           this._lastPos = { x: p.values[0], y: p.values[1] };
           break;
         case 'L':
-          this._drawPathCircle(p.values[0], p.values[1]);
+          this._drawPathCircle(p.values[0], p.values[1], p, 0);
           break;
         case 'H':
           break;
@@ -46,96 +43,91 @@ export class PathExtension extends AbstractExtension {
         case 'C':
           this._drawPathLine(this._lastPos.x, this._lastPos.y, p.values[0], p.values[1]);
           this._drawPathLine(p.values[4], p.values[5], p.values[2], p.values[3]);
-          this._drawPathCircle(p.values[0], p.values[1]);
-          this._drawPathCircle(p.values[2], p.values[3]);
-          this._drawPathCircle(p.values[4], p.values[5]);
+          this._drawPathCircle(p.values[0], p.values[1], p, 0);
+          this._drawPathCircle(p.values[2], p.values[3], p, 2);
+          this._drawPathCircle(p.values[4], p.values[5], p, 4);
           this._lastPos = { x: p.values[4], y: p.values[5] };
           break;
         case 'c':
           this._drawPathLine(this._lastPos.x, this._lastPos.y, p.values[0], p.values[1]);
           this._drawPathLine(this._lastPos.x + p.values[4], this._lastPos.y + p.values[5], p.values[2], p.values[3]);
-          this._drawPathCircle(p.values[0], p.values[1]);
-          this._drawPathCircle(p.values[2], p.values[3]);
-          this._drawPathCircle(this._lastPos.x + p.values[4], this._lastPos.y + p.values[5]);
+          this._drawPathCircle(p.values[0], p.values[1], p, 0);
+          this._drawPathCircle(p.values[2], p.values[3], p, 2);
+          this._drawPathCircle(this._lastPos.x + p.values[4], this._lastPos.y + p.values[5], p, 4);
           this._lastPos = { x: p.values[4], y: p.values[5] };
           break;
         case 'S':
-          this._drawPathCircle(p.values[0], p.values[1]);
-          this._drawPathCircle(p.values[2], p.values[3]);
+          this._drawPathCircle(p.values[0], p.values[1], p, 0);
+          this._drawPathCircle(p.values[2], p.values[3], p, 2);
           break;
         case 'Q':
-          this._drawPathCircle(p.values[0], p.values[1]);
-          this._drawPathCircle(p.values[2], p.values[3]);
+          this._drawPathCircle(p.values[0], p.values[1], p, 0);
+          this._drawPathCircle(p.values[2], p.values[3], p, 2);
           break;
         case 'T':
-          this._drawPathCircle(p.values[0], p.values[1]);
+          this._drawPathCircle(p.values[0], p.values[1], p, 0);
           break;
         case 'A':
-          this._drawPathCircle(p.values[0], p.values[1]);
-          this._drawPathCircle(p.values[5], p.values[6]);
+          this._drawPathCircle(p.values[0], p.values[1], p, 0);
+          this._drawPathCircle(p.values[5], p.values[6], p, 5);
           break;
       }
     }
   }
 
-  pointerEvent(event: PointerEvent) {
+  pointerEvent(event: PointerEvent, circle: SVGCircleElement, p: PathData, index: number) {
     event.stopPropagation();
-
-    this._rect = this.extendedItem.element.getBoundingClientRect();
-    this._computed = getComputedStyle(this.extendedItem.element);
-    this._to = this._computed.transformOrigin.split(' ');
 
     switch (event.type) {
       case EventNames.PointerDown:
         (<Element>event.target).setPointerCapture(event.pointerId);
         this._startPos = { x: event.x, y: event.y };
-        console.log("Pointer Down");
+        this._circlePos = { x: parseFloat(circle.getAttribute("cx")), y: parseFloat(circle.getAttribute("cy")) }
+
         break;
 
       case EventNames.PointerMove:
-        console.log("Pointer Move");
         if (this._startPos && event.buttons > 0) {
-          const dx = event.x - this._startPos.x;
-          const dy = event.y - this._startPos.y;
-          this._circle.setAttribute('cx', <any>(this._rect.x - this.designerCanvas.containerBoundingRect.x + Number.parseFloat(this._to[0].replace('px', '')) + dx));
-          this._circle.setAttribute('cy', <any>(this._rect.y - this.designerCanvas.containerBoundingRect.y + Number.parseFloat(this._to[1].replace('px', '')) + dy));
-          this._circle2.setAttribute('cx', <any>(this._rect.x - this.designerCanvas.containerBoundingRect.x + Number.parseFloat(this._to[0].replace('px', '')) + dx));
-          this._circle2.setAttribute('cy', <any>(this._rect.y - this.designerCanvas.containerBoundingRect.y + Number.parseFloat(this._to[1].replace('px', '')) + dy));
+          this._lastPos = { x: this._startPos.x, y: this._startPos.y };
+          const cx = event.x - this._lastPos.x + this._circlePos.x;
+          const cy = event.y - this._lastPos.y + this._circlePos.y;
+          const dx = this._circlePos.x - cx;
+          const dy = this._circlePos.y - cy;
+          console.log("Path")
+          console.log(this._pathdata)
+          console.log("CirclePos");
+          console.log(this._circlePos);
+          console.log("cx + " + cx + " / cy " + cy);
+          console.log("dx + " + dx + " / dy " + dy);
+          console.log(p.values);
+          circle.setAttribute("cx", (cx).toString());
+          circle.setAttribute("cy", (cy).toString());
+          p.values[index] = this._circlePos.x + dx;
+          p.values[index + 1] = this._circlePos.y + dy;
         }
         break;
 
       case EventNames.PointerUp:
-        console.log("Pointer Up");
         (<Element>event.target).releasePointerCapture(event.pointerId);
-        if (this._startPos) {
-          const dx = event.x - this._startPos.x;
-          const dy = event.y - this._startPos.y;
-          const x = Number.parseFloat(this._to[0].replace('px', ''));
-          const y = Number.parseFloat(this._to[1].replace('px', ''));
-          const newX = (dx + x);
-          const newY = (dy + y);
-          const przX = Math.round(newX / this._rect.width * 10000) / 100; //round to 2 decimal places
-          const przY = Math.round(newY / this._rect.height * 10000) / 100;
-          //this.extendedItem.setStyle('transform-origin',newX + 'px ' + newY + 'px');
-          this.extendedItem.setStyle('transform-origin', przX + '% ' + przY + '%');
-          this.refresh();
-          this._startPos = null;
-        }
+        this._drawPath(this._pathdata);
+        this._startPos = null;
         break;
     }
   }
 
-  _drawPathCircle(x: number, y: number) {
-    this._rect = this.extendedItem.element.getBoundingClientRect();
-    this._computed = getComputedStyle(this.extendedItem.element);
-    this._to = this._computed.transformOrigin.split(' ');
+  _drawPath(path: PathData[]) {
+    let pathD: string;
+    for(let p of path){
+      pathD += p.type + p.values[0] + " " + p.values[1];
+    }
+    console.log(pathD);
+  }
 
-    this._circle = this._drawCircle(this._parentRect.x - this.designerCanvas.containerBoundingRect.x + x, this._parentRect.y - this.designerCanvas.containerBoundingRect.y + y, 3, 'svg-path');
-    this._circle.addEventListener(EventNames.PointerDown, event => this.pointerEvent(event));
-    this._circle.addEventListener(EventNames.PointerMove, event => this.pointerEvent(event));
-    this._circle.addEventListener(EventNames.PointerUp, event => this.pointerEvent(event));
-    this._circle2 = this._drawCircle(this._rect.x - this.designerCanvas.containerBoundingRect.x + Number.parseFloat(this._to[0].replace('px', '')), this._rect.y - this.designerCanvas.containerBoundingRect.y + Number.parseFloat(this._to[1].replace('px', '')), 1, 'svg-transform-origin');
-    this._circle2.setAttribute('style', 'pointer-events: none');
+  _drawPathCircle(x: number, y: number, p: PathData, index: number) {
+    let circle = this._drawCircle(this._parentRect.x - this.designerCanvas.containerBoundingRect.x + x, this._parentRect.y - this.designerCanvas.containerBoundingRect.y + y, 3, 'svg-path');
+    circle.addEventListener(EventNames.PointerDown, event => this.pointerEvent(event, circle, p, index));
+    circle.addEventListener(EventNames.PointerMove, event => this.pointerEvent(event, circle, p, index));
+    circle.addEventListener(EventNames.PointerUp, event => this.pointerEvent(event, circle, p, index));
   }
 
   _drawPathLine(x1: number, y1: number, x2: number, y2: number) {

--- a/src/elements/widgets/designerView/extensions/PathExtension.ts
+++ b/src/elements/widgets/designerView/extensions/PathExtension.ts
@@ -14,6 +14,7 @@ export class PathExtension extends AbstractExtension {
   private _parentRect: DOMRect;
   private _startPos: IPoint;
   private _circlePos: IPoint;
+  private _originalPathPoint: IPoint;
   private _pathdata: PathData[];
 
   constructor(extensionManager: IExtensionManager, designerView: IDesignerCanvas, extendedItem: IDesignItem) {
@@ -83,6 +84,8 @@ export class PathExtension extends AbstractExtension {
         (<Element>event.target).setPointerCapture(event.pointerId);
         this._startPos = { x: event.x, y: event.y };
         this._circlePos = { x: parseFloat(circle.getAttribute("cx")), y: parseFloat(circle.getAttribute("cy")) }
+        this._originalPathPoint = { x: p.values[index], y: p.values[index + 1] }
+
 
         break;
 
@@ -91,36 +94,29 @@ export class PathExtension extends AbstractExtension {
           this._lastPos = { x: this._startPos.x, y: this._startPos.y };
           const cx = event.x - this._lastPos.x + this._circlePos.x;
           const cy = event.y - this._lastPos.y + this._circlePos.y;
-          const dx = this._circlePos.x - cx;
-          const dy = this._circlePos.y - cy;
-          console.log("Path")
-          console.log(this._pathdata)
-          console.log("CirclePos");
-          console.log(this._circlePos);
-          console.log("cx + " + cx + " / cy " + cy);
-          console.log("dx + " + dx + " / dy " + dy);
-          console.log(p.values);
-          circle.setAttribute("cx", (cx).toString());
-          circle.setAttribute("cy", (cy).toString());
-          p.values[index] = this._circlePos.x + dx;
-          p.values[index + 1] = this._circlePos.y + dy;
+          const dx = cx - this._circlePos.x;
+          const dy = cy - this._circlePos.y;
+          p.values[index] = this._originalPathPoint.x + dx;
+          p.values[index + 1] = this._originalPathPoint.y + dy;
+          this._drawPath(this._pathdata, index);
         }
         break;
 
       case EventNames.PointerUp:
         (<Element>event.target).releasePointerCapture(event.pointerId);
-        this._drawPath(this._pathdata);
         this._startPos = null;
+        this._circlePos = null;
+        this._lastPos = null;
         break;
     }
   }
 
-  _drawPath(path: PathData[]) {
-    let pathD: string;
-    for(let p of path){
-      pathD += p.type + p.values[0] + " " + p.values[1];
+  _drawPath(path: PathData[], index: number) {
+    let pathD: string = "";
+    for (let p of path) {
+      pathD += p.type + p.values[index] + " " + p.values[index + 1];
     }
-    console.log(pathD);
+    this.extendedItem.setAttribute("d", pathD);
   }
 
   _drawPathCircle(x: number, y: number, p: PathData, index: number) {

--- a/src/elements/widgets/designerView/tools/DrawPathTool.ts
+++ b/src/elements/widgets/designerView/tools/DrawPathTool.ts
@@ -23,6 +23,7 @@ export class DrawPathTool implements ITool {
   private _eventStarted = false;
   private _lastPoint: IPoint = { x: 0, y: 0 };
   private _savedPoint: IPoint = { x: 0, y: 0 };
+  private _startPoint: IPoint = { x: 0, y: 0 };
 
   constructor() {
   }
@@ -51,6 +52,7 @@ export class DrawPathTool implements ITool {
           this._path.setAttribute("fill", designerCanvas.serviceContainer.globalContext.fillBrush);
           this._path.setAttribute("stroke-width", designerCanvas.serviceContainer.globalContext.strokeThickness);
           designerCanvas.overlayLayer.addOverlay(this._path, OverlayLayer.Foregorund);
+          this._startPoint = currentPoint;
         }
 
         if (this._lastPoint.x === currentPoint.x && this._lastPoint.y === currentPoint.y && !this._samePoint) {
@@ -88,7 +90,7 @@ export class DrawPathTool implements ITool {
         if (this._eventStarted && !this._pointerMoved) {
           this._p2pMode = true;
         }
-        if (this._p2pMode && !this._samePoint) {
+        if (this._p2pMode && !this._samePoint && this._startPoint.x != currentPoint.x && this._startPoint.y != currentPoint.y) {
           if (this._path) {
             if (event.shiftKey) {
               let straightLine = straightenLine(this._savedPoint, currentPoint);

--- a/src/elements/widgets/designerView/tools/TextTool.ts
+++ b/src/elements/widgets/designerView/tools/TextTool.ts
@@ -1,12 +1,13 @@
+import { EventNames } from '../../../../enums/EventNames.js';
 import { ServiceContainer } from '../../../services/ServiceContainer.js';
 import { IDesignerCanvas } from '../IDesignerCanvas';
 import { ITool } from './ITool';
 
 export class TextTool implements ITool {
-  
+
   constructor() {
   }
-  
+
   activated(serviceContainer: ServiceContainer) {
   }
 
@@ -15,7 +16,35 @@ export class TextTool implements ITool {
 
   readonly cursor = 'text';
 
+  private _text: SVGTextElement;
+
   pointerEventHandler(designerCanvas: IDesignerCanvas, event: PointerEvent, currentElement: Element) {
-   
+    const currentPoint = designerCanvas.getNormalizedEventCoordinates(event);
+    //const offset = 50;
+
+    addEventListener("keyup", function(event){
+      if(event.key === 'Enter') {
+        console.log("Enter Pressed");
+        event.preventDefault();
+      }
+    });
+
+    switch (event.type) {
+      case EventNames.PointerDown:
+        (<Element>event.target).setPointerCapture(event.pointerId);
+        this._text = document.createElementNS("http://www.w3.org/2000/svg", "text");
+        this._text.setAttribute("x", currentPoint.x.toString());
+        this._text.setAttribute("y", currentPoint.y.toString());
+
+        break;
+
+
+        case EventNames.KeyUp:
+        //if(event.key === 'Enter'){
+
+        //}
+        break;
+
+    }
   }
 }


### PR DESCRIPTION
PathExtension.ts: Path points can be moved around (a little bug: when pointer is moved to quickly, the point will be lost)

DrawPathTool.ts: fixed that two start points are created
