### PR TITLE
SVG Extensions

### DIFF
--- a/src/elements/helper/PathDataPolyfill.ts
+++ b/src/elements/helper/PathDataPolyfill.ts
@@ -1176,25 +1176,25 @@ export function moveSVGPath(path: SVGPathElement, xFactor: number, yFactor: numb
         case ('l'):
         case ('T'):
         case ('t'):
-          newPathData += p.type + (p.values[0] - xFactor) + " " + (p.values[1] - yFactor);
+          newPathData += p.type + " " + (p.values[0] - xFactor) + " " + (p.values[1] - yFactor) + " ";
           break;
         case ('Z'):
         case ('z'):
-          newPathData += p.type;
+          newPathData += p.type + " ";
           break;
         case ('C'):
         case ('c'):
-          newPathData += p.type + (p.values[0] - xFactor) + " " + (p.values[1] - yFactor) + " " + (p.values[2] - xFactor) + " " + (p.values[3] - yFactor) + " " + (p.values[4] - xFactor) + " " + (p.values[5] - yFactor);
+          newPathData += p.type + " " + (p.values[0] - xFactor) + " " + (p.values[1] - yFactor) + " " + (p.values[2] - xFactor) + " " + (p.values[3] - yFactor) + " " + (p.values[4] - xFactor) + " " + (p.values[5] - yFactor) + " ";
           break;
         case ('S'):
         case ('s'):
         case ('Q'):
         case ('q'):
-          newPathData += p.type + (p.values[0] - xFactor) + " " + (p.values[1] - yFactor) + " " + (p.values[2] - xFactor) + " " + (p.values[3] - yFactor);
+          newPathData += p.type + " " + (p.values[0] - xFactor) + " " + (p.values[1] - yFactor) + " " + (p.values[2] - xFactor) + " " + (p.values[3] - yFactor) + " ";
           break;
         case ('A'):
         case ('a'):
-          newPathData += p.type + (p.values[0] - xFactor) + " " + (p.values[1] - yFactor) + " " + p.values[2] + " " + p.values[3] + " " + p.values[4] + " " + (p.values[5] - xFactor) + " " + (p.values[6] - yFactor);
+          newPathData += p.type + " " + (p.values[0] - xFactor) + " " + (p.values[1] - yFactor) + " " + p.values[2] + " " + p.values[3] + " " + p.values[4] + " " + (p.values[5] - xFactor) + " " + (p.values[6] - yFactor) + " ";
           break;
       }
     }

--- a/src/elements/widgets/designerView/extensions/ExtensionManager.ts
+++ b/src/elements/widgets/designerView/extensions/ExtensionManager.ts
@@ -223,7 +223,7 @@ export class ExtensionManager implements IExtensionManager {
     }
   }
 
-  refreshExtensions(designItems: IDesignItem[], extensionType?: ExtensionType) {
+  refreshExtensions(designItems: IDesignItem[], extensionType?: ExtensionType, ignoredExtension?: any) {
     if (designItems) {
       if (extensionType) {
         for (let i of designItems) {
@@ -231,7 +231,8 @@ export class ExtensionManager implements IExtensionManager {
           if (exts) {
             for (let e of exts) {
               try {
-                e.refresh();
+                if (e != ignoredExtension)
+                  e.refresh();
               }
               catch (err) {
                 console.error(err);
@@ -244,6 +245,7 @@ export class ExtensionManager implements IExtensionManager {
           for (let appE of i.appliedDesignerExtensions) {
             for (let e of appE[1]) {
               try {
+                if(e != ignoredExtension)
                 e.refresh();
               }
               catch (err) {
@@ -256,18 +258,18 @@ export class ExtensionManager implements IExtensionManager {
     }
   }
 
-  refreshAllExtensions(designItems: IDesignItem[]) {
+  refreshAllExtensions(designItems: IDesignItem[], ignoredExtension?: any) {
     if (designItems) {
-      this.refreshExtensions(designItems, ExtensionType.Permanent);
-      this.refreshExtensions(designItems, ExtensionType.Selection);
-      this.refreshExtensions(designItems, ExtensionType.PrimarySelection);
-      this.refreshExtensions(designItems, ExtensionType.PrimarySelectionContainer);
-      this.refreshExtensions(designItems, ExtensionType.MouseOver);
-      this.refreshExtensions(designItems, ExtensionType.OnlyOneItemSelected);
-      this.refreshExtensions(designItems, ExtensionType.MultipleItemsSelected);
-      this.refreshExtensions(designItems, ExtensionType.ContainerDragOver);
-      this.refreshExtensions(designItems, ExtensionType.ContainerDrag);
-      this.refreshExtensions(designItems, ExtensionType.Doubleclick);
+      this.refreshExtensions(designItems, ExtensionType.Permanent, ignoredExtension);
+      this.refreshExtensions(designItems, ExtensionType.Selection, ignoredExtension);
+      this.refreshExtensions(designItems, ExtensionType.PrimarySelection, ignoredExtension);
+      this.refreshExtensions(designItems, ExtensionType.PrimarySelectionContainer, ignoredExtension);
+      this.refreshExtensions(designItems, ExtensionType.MouseOver, ignoredExtension);
+      this.refreshExtensions(designItems, ExtensionType.OnlyOneItemSelected, ignoredExtension);
+      this.refreshExtensions(designItems, ExtensionType.MultipleItemsSelected, ignoredExtension);
+      this.refreshExtensions(designItems, ExtensionType.ContainerDragOver, ignoredExtension);
+      this.refreshExtensions(designItems, ExtensionType.ContainerDrag, ignoredExtension);
+      this.refreshExtensions(designItems, ExtensionType.Doubleclick, ignoredExtension);
     }
   }
 

--- a/src/elements/widgets/designerView/extensions/IExtensionManger.ts
+++ b/src/elements/widgets/designerView/extensions/IExtensionManger.ts
@@ -8,6 +8,6 @@ export interface IExtensionManager {
   removeExtensions(designItems: IDesignItem[], extensionType?: ExtensionType);
   refreshExtension(designItem: IDesignItem, extensionType?: ExtensionType);
   refreshExtensions(designItems: IDesignItem[], extensionType?: ExtensionType);
-  refreshAllExtensions(designItems: IDesignItem[]);
+  refreshAllExtensions(designItems: IDesignItem[], ignoredExtension?: any);
   refreshAllAppliedExtentions();
 }

--- a/src/elements/widgets/designerView/extensions/svg/EllipsisExtension.ts
+++ b/src/elements/widgets/designerView/extensions/svg/EllipsisExtension.ts
@@ -92,6 +92,8 @@ export class EllipsisExtension extends AbstractExtension {
                     e.setAttribute("rx", this._newRx.toString());
                     e.setAttribute("ry", this._newRy.toString());
 
+                    this.designerCanvas.extensionManager.refreshAllExtensions([this.extendedItem], this);
+
                     this._redrawPathCircle(this._cx, this._cy - this._newRy, this._circle1);
                     this._redrawPathCircle(this._cx + this._newRx, this._cy, this._circle2);
                     this._redrawPathCircle(this._cx, this._cy + this._newRy, this._circle3);
@@ -129,6 +131,7 @@ export class EllipsisExtension extends AbstractExtension {
         let circle = this._drawCircle((this._parentRect.x - this.designerCanvas.containerBoundingRect.x) / this.designerCanvas.scaleFactor + x, (this._parentRect.y - this.designerCanvas.containerBoundingRect.y) / this.designerCanvas.scaleFactor + y, 5 / this.designerCanvas.scaleFactor, 'svg-path', oldCircle);
         circle.style.strokeWidth = (1 / this.designerCanvas.zoomFactor).toString();
         return circle;
+
     }
 
 

--- a/src/elements/widgets/designerView/extensions/svg/LineExtension.ts
+++ b/src/elements/widgets/designerView/extensions/svg/LineExtension.ts
@@ -69,6 +69,8 @@ export class LineExtension extends AbstractExtension {
                         this._newCirclePoint = { x: this._circlePos.x + dx, y: this._circlePos.y + dy }
                         this._newLinePoint = { x: this._originalPoint.x + dx, y: this._originalPoint.y + dy }
                     }
+                    this.designerCanvas.extensionManager.refreshAllExtensions([this.extendedItem], this);
+
                     circle.setAttribute("cx", this._newCirclePoint.x.toString());
                     circle.setAttribute("cy", this._newCirclePoint.y.toString());
                     l.setAttribute("x" + index, this._newLinePoint.x.toString());

--- a/src/elements/widgets/designerView/extensions/svg/PathExtension.ts
+++ b/src/elements/widgets/designerView/extensions/svg/PathExtension.ts
@@ -158,6 +158,7 @@ export class PathExtension extends AbstractExtension {
               circle.setAttribute("cy", (this._circlePos.y + dy).toString());
             }
           }
+          this.designerCanvas.extensionManager.refreshAllExtensions([this.extendedItem], this);
           this.extendedItem.element.setAttribute("d", createPathD(this._pathdata));
         }
         break;

--- a/src/elements/widgets/designerView/extensions/svg/RectExtension.ts
+++ b/src/elements/widgets/designerView/extensions/svg/RectExtension.ts
@@ -114,6 +114,8 @@ export class RectExtension extends AbstractExtension {
                     circle.setAttribute("cx", (this._circlePos.x + dx).toString());
                     circle.setAttribute("cy", (this._circlePos.y + dy).toString());
 
+                    this.designerCanvas.extensionManager.refreshAllExtensions([this.extendedItem], this);
+
                     this._redrawPathCircle(this._rect.x, this._rect.y, this._circle1);
                     this._redrawPathCircle(this._rect.x + this._rect.w, this._rect.y, this._circle2);
                     this._redrawPathCircle(this._rect.x + this._rect.w, this._rect.y + this._rect.h, this._circle3);


### PR DESCRIPTION
+ added whit spaces to SVG Path data to improve readability
+ added the possibility to ignore an extension when refreshAllExtension() is used
+ outline will now refresh when SVG Elements are moved